### PR TITLE
Remove double quotes from variable value

### DIFF
--- a/cron/entrypoint.sh
+++ b/cron/entrypoint.sh
@@ -15,7 +15,7 @@ do
    case "$item" in
        CRONTASK_*)
             ENVVAR=`echo $item | cut -d \= -f 1`
-            printenv $ENVVAR >> $cronFile
+            printenv $ENVVAR | sed 's/"\(.*\)"/\1/' >> $cronFile
             ;;
    esac
 done


### PR DESCRIPTION
Crontab not recognized command in /etc/crontab file, because it saved with double quotes.
When quotes is not saved in file, cron successfully run specified command.